### PR TITLE
Directly add config vars rather than config script

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -32,6 +32,13 @@ js = Bundle('js/main.js', filters=('browserify',), output='lib/main.js')
 if server.debug:
     js.config['BROWSERIFY_EXTRA_ARGS'] = ['--debug']
 
+js_envs = {
+    'GAPI_KEY': config.auth['google']['client-id']
+}
+
 js.config['BROWSERIFY_BIN'] = 'node_modules/.bin/browserify'
-js.config['BROWSERIFY_TRANSFORMS'] = ['babelify']
+js.config['BROWSERIFY_TRANSFORMS'] = [
+    'babelify',
+    ['envify', *[arg for (key, value) in js_envs.items() for arg in ('--' + key, value)]]
+]
 assets.register('js_all', js)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babelify": "^8.0.0",
     "browserify": "^14.5.0",
     "clean-css": "^3.4.24",
+    "envify": "^4.1.0",
     "highlight.js": "^9.12.0",
     "markdown-it": "^8.4.0",
     "markdown-it-katex": "^2.0.3",

--- a/static/js/template/login/AuthModalTemplate.js
+++ b/static/js/template/login/AuthModalTemplate.js
@@ -26,7 +26,7 @@ export default class AuthModalTemplate extends ModalTemplate {
         await gapi.loadAsync('auth2');
         
         gapi.auth2.init({
-            client_id: window.config.pv_gid,
+            client_id: process.env.GAPI_KEY,
             cookiepolicy: 'single_host_origin',
             fetch_basic_profile: true
         }).attachClickHandler(googleTrigger, {}, (googleUser) => {

--- a/templates/layouts/page.html
+++ b/templates/layouts/page.html
@@ -9,9 +9,6 @@
     
     {% if g.user is none -%}
     <script src="https://apis.google.com/js/api:client.js"></script>
-    <script type="text/javascript">window.config={
-        pv_gid: "{{ opts.auth['google']['client-id'] }}"
-    };</script>
     {%- endif %}
     
     {% assets "css_all" -%}


### PR DESCRIPTION
Previously there was a <script> injected which made a global config
object with data. This has not been replaced because it is a bad idea to
just keep things like that sitting around globally and also because this
is a lot cleaner.

Signed-off-by: Vihan B <contact@vihan.org>