### PR TITLE
Fix broken pipe error

### DIFF
--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -1,8 +1,8 @@
-from app.server import server
-from app.helpers.render import render_template, render_json
-import app.tasks as tasks
-from app.controllers import post
 from flask import request, redirect, url_for, g, abort
+from app.helpers.render import render_template, render_json
+from app.controllers import post
+from app.server import server
+import app.tasks as tasks
 
 
 @server.route("/posts")
@@ -20,9 +20,9 @@ def get_post(post_id):
     matched_post = post.get_post(post_id=post_id)
     if matched_post is None:
         return abort(404)
-
-    # TODO: async loading
+    
     body = tasks.markdown.render_markdown.delay(matched_post.body).wait()
+    
     if body is None:
         return abort(500)
 

--- a/app/tasks/markdown.py
+++ b/app/tasks/markdown.py
@@ -12,7 +12,7 @@ def fork_helper():
     return markdown_local.render_proc
 
 @celery_app.task
-def render_markdown(string, id=None, force=False):
+def render_markdown(string):
     helper = fork_helper()
     
     helper.stdin.write(string.encode('utf-8'))

--- a/app/tasks/markdown.py
+++ b/app/tasks/markdown.py
@@ -1,17 +1,23 @@
 from app.instances.celery import celery_app
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 from misc import md_exe
+from threading import local
 
-render_proc = None
+markdown_local = local()
+
+def fork_helper():
+    if not (hasattr(markdown_local, 'render_proc') and markdown_local.render_proc is not None):
+        markdown_local.render_proc = Popen(['node', md_exe], stdout=PIPE, stdin=PIPE)
+    
+    return markdown_local.render_proc
 
 @celery_app.task
-def render_markdown(string):
-    global render_proc
+def render_markdown(string, id=None, force=False):
+    helper = fork_helper()
     
-    if render_proc is None:
-        render_proc = Popen(['node', md_exe], stdout=PIPE, stdin=PIPE, stderr=None)
+    helper.stdin.write(string.encode('utf-8'))
+    helper.stdin.flush()
+    read_len = int.from_bytes(helper.stdout.read(4), byteorder='little')
+    res = helper.stdout.read(read_len).decode('utf-8')
     
-    render_proc.stdin.write(string.encode('utf-8'))
-    render_proc.stdin.flush()
-    read_len = int.from_bytes(render_proc.stdout.read(4), byteorder='little')
-    return render_proc.stdout.read(read_len).decode('utf-8')
+    return res


### PR DESCRIPTION
This fixes broken pipe error which was apparently caused when celery
delegate the rendering to a different thread than was initally used for
initalizing the pipe to the rendering process.

Signed-off-by: Vihan B <contact@vihan.org>